### PR TITLE
Installation via composer, Update for Symfony ~2.3, Bugfixes

### DIFF
--- a/Local/Sensio/Bundle/FrameworkExtraBundle/Configuration/Tal.php
+++ b/Local/Sensio/Bundle/FrameworkExtraBundle/Configuration/Tal.php
@@ -30,6 +30,15 @@ class Tal implements ConfigurationInterface
 
     protected $extension;
 
+    /**
+     * Returns whether multiple annotations of this type are allowed
+     *
+     * @return Boolean
+     */
+    function allowArray()
+    {
+        return false;
+    }
 
     /**
      * Returns the array of templates variables.

--- a/Local/Sensio/Bundle/FrameworkExtraBundle/Tal/TalListener.php
+++ b/Local/Sensio/Bundle/FrameworkExtraBundle/Tal/TalListener.php
@@ -18,7 +18,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 class TalListener
 {
     /**
-     * @var Symfony\Component\DependencyInjection\ContainerInterface
+     * @var \Symfony\Component\DependencyInjection\ContainerInterface
      */
     protected $container;
 

--- a/Phptal/PhptalEngine.php
+++ b/Phptal/PhptalEngine.php
@@ -186,15 +186,9 @@ class PhptalEngine implements EngineInterface
     public function renderResponse($view, array $parameters = array(), Response $response = null )
     {
         if (null === $response) {
-            $response = $this->container->get('response');
+            $response = new Response();
         }
         $response->setContent($this->render($view, $parameters));
         return $response;
     }
-
-
-
-
-
-
 }

--- a/Phptal/PhptalEngine.php
+++ b/Phptal/PhptalEngine.php
@@ -78,7 +78,7 @@ class PhptalEngine implements EngineInterface
         }elseif($options['output_format']=='XML'){
             $template->setOutputMode( \PHPTAL::XML );
         }else{
-            throw new \InvalidArgumentException('Unsupported output mode '.$output_format);
+            throw new \InvalidArgumentException('Unsupported output mode ' . $options['output_format']);
         }
 
         // force reparse (for debug prefilter)

--- a/README.markdown
+++ b/README.markdown
@@ -3,50 +3,22 @@ NeniPhptalBundle
 
 Renderer TAL in Symfony2 with [PHPTAL](http://phptal.org/).
 
-
-
 ## INSTALLATION
 
+### 1. Install via composer
 
-
-### 1. Add this bundle to your project
-
-        $ git clone git://github.com/neni/NeniPhptalBundle.git vendor/bundles/Neni/PhptalBundle
-
-or as submodule
-
-        $ git submodule add git://github.com/neni/NeniPhptalBundle.git vendor/bundles/Neni/PhptalBundle
-        $ git submodule update --init
+        $ composer require neni/phptal-bundle
         
+As there are no tags yet, you probably want to require the "*@dev" version. The neni/phptal-bundle itself has a *@dev dependency on phptal - this may conflict with the minimum stability settings of your project. If so, you probably want to
 
-### 2. Install PHPTal
-
-if PHPTal is not installed
-
-        $ git svn clone https://svn.motion-twin.com/phptal/trunk vendor/Phptal-svn
-
-
-_it is not possible to add a SVN repository as submodule (or I do not know how to make this)._
+        $ composer require phptal/phptal
+        
+with the "*@dev" version manually to resolve this conflict.
 
 
-### 3. Add the bundle to your application kernel:
+### 2. Add bundle to application kernel
 
-add in file "app/autoload.php"
-
-        $loader->registerNamespaces(array(
-             // if use of Sensio's FrameworkExtraBundle (annotation with @extra:Tal)
-             'Sensio' => array(
-                            __DIR__.'/../vendor/bundles',
-                            __DIR__.'/../vendor/bundles/Neni/PhptalBundle/Local'
-                       ),
-            
-             // ...
-        '    Neni' => __DIR__.'/../vendor/bundles',
-             // ...
-        ));
-
-
-add in file "app/AppKernel.php"
+Add in file "app/AppKernel.php":
 
         public function registerBundles()
         {
@@ -63,8 +35,6 @@ add in file "app/AppKernel.php"
            // ...
         ));
         
-
-
 change in the configuration file ("app/config/config.yml")
 
        framework:

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,8 @@
     "name": "neni/phptal-bundle",
     "description": "Renderer TAL in Symfony2 with PHPTAL.",
     "require": {
-        "phptal/phptal": "*@dev"
+        "phptal/phptal": "*@dev",
+        "symfony/symfony": "~2.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "neni/phptal-bundle",
+    "description": "Renderer TAL in Symfony2 with PHPTAL.",
+    "require": {
+        "phptal/phptal": "*@dev"
+    },
+    "autoload": {
+        "psr-4": {
+            "Neni\\PhptalBundle\\": ""
+        }
+    }
+}


### PR DESCRIPTION
Although in the end we decided not to use your bundle, we did some little improvements on the way. Apart from simple bug fixes, namely the installation via composer (however, the way described in the README.md won't work until you publish it at packagist,org) and some adjustments for Symfony ~2.3.
